### PR TITLE
Feature/relay implement `/set_relay#` service and `/relay#_status` topics

### DIFF
--- a/include/leo_firmware/wheel_controller.h
+++ b/include/leo_firmware/wheel_controller.h
@@ -1,6 +1,7 @@
 #ifndef LEO_FIRMWARE_INCLUDE_WHEEL_CONTROLLER_H_
 #define LEO_FIRMWARE_INCLUDE_WHEEL_CONTROLLER_H_
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <utility>

--- a/main.cpp
+++ b/main.cpp
@@ -403,7 +403,7 @@ void odomLoop() {
 
   while (true) {
     if (!publish_odom) {
-      odom.header.stamp = nh.now();
+      pose.header.stamp = odom.header.stamp = nh.now();
 
       Odom odo = dc.getOdom();
       odom.twist.linear.x = odo.vel_lin;


### PR DESCRIPTION
The asyncronous nature of topics was giving me unreliable relay status. 

I implemented the `/core2/set_relay1` to 4 service to allow setting the relays in a blocking (synchronous) way.

I've also added `/relay#_status` topics but this could also be replaced by a `/core2/get_relay#` service.